### PR TITLE
[WIP] Function to register user-defined glass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ spectral lines.csv
 getData.py
 rindexinfo-traverse_library.py
 opticalglass-pyscaffold-4_3/*
+
+# vscode
+*.code-workspace
+
+# pytest
+__pycache__

--- a/src/opticalglass/__init__.py
+++ b/src/opticalglass/__init__.py
@@ -53,3 +53,4 @@ except:
 finally:
     del version
 
+from .glassfactory import register_glass

--- a/src/opticalglass/glassfactory.py
+++ b/src/opticalglass/glassfactory.py
@@ -15,6 +15,7 @@ import logging
 from . import glass as cat_glass
 from . import glasserror as ge
 from . import rindexinfo
+from .opticalmedium import OpticalMedium
 
 from .caselessDictionary import CaselessDictionary
 
@@ -25,6 +26,22 @@ _catalog_list = CaselessDictionary()
 CDGM, Hikari, Hoya, Ohara, Schott, Sumita = range(6)
 _cat_names = ["CDGM", "Hikari", "Hoya", "Ohara", "Schott", "Sumita"]
 _cat_names_uc = [cat.upper() for cat in _cat_names]
+
+
+# A place to hold user-registered glasses:
+_custom_glass_registry = {}  
+
+
+def register_glass(
+    medium: OpticalMedium
+):
+    """
+    Register a custom glass.
+    """
+    key = (medium.name(), medium.catalog_name())
+    if not isinstance(medium, OpticalMedium):
+        raise TypeError('medium must be an instance of OpticalMedium')
+    _custom_glass_registry[key] = medium
 
 
 def create_glass(*name_catalog):
@@ -50,6 +67,8 @@ def create_glass(*name_catalog):
     def _create_glass(name, catalog):
         if catalog == "rindexinfo":
             return rindexinfo.create_glass(name)
+        elif (name, catalog) in _custom_glass_registry:  # for custom glasses
+            return _custom_glass_registry[(name, catalog)]
         else:
             gn_decode = cat_glass.decode_glass_name(name)
             if catalog not in _catalog_list:

--- a/src/opticalglass/test/test_create_glass.py
+++ b/src/opticalglass/test/test_create_glass.py
@@ -8,6 +8,7 @@
 import unittest
 from opticalglass.glassfactory import create_glass
 from opticalglass import glasserror as ge
+from opticalglass import opticalmedium
 
 
 class CreateGlassTestCase(unittest.TestCase):
@@ -62,6 +63,18 @@ class CreateGlassTestCase(unittest.TestCase):
                           create_glass, 'N-BK7, xSchott')
         self.assertRaises(ge.GlassCatalogNotFoundError, 
                           create_glass, 'N-BK7','xSchott')
+
+    def test_register_glass(self):
+        """ test registering a glass """
+        from opticalglass.glassfactory import register_glass
+        from opticalglass import glasserror as ge
+
+        # register a glass
+        register_glass(opticalmedium.InterpolatedMedium(
+            'myglass', [(600, 1.5), (610, 1.6), (620, 1.61), (630, 1.62)], cat='mycatalog')
+        )
+        medium = create_glass('myglass', 'mycatalog')
+        self.assertIsInstance(medium, opticalmedium.OpticalMedium)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,

First, thank you for creating and maintaining such a useful package (and for the seamless integration with ray-optics). 
I’d love to get your thoughts on a possible enhancement: letting users register custom media in a global registry.

While it’s already possible to load a custom medium via the existing API (and through ray-optics), I frequently reuse the same materials across many projects. Being able to register a glass once—so that any subsequent calls to `create_glass("MyGlass", "MyCatalog")` or loading a .zmx file simply recognizes “MyGlass” automatically—would greatly streamline my workflow.

### Proposed usage

```python
import opticalglass
from opticalglass.opticalmedium import InterpolatedMedium

# Define a custom glass using existing InterpolatedMedium
VIG06 = InterpolatedMedium(
    'VIG06',
    [
        (1.000, 2.931620090459),
        (1.110, 2.9007004740473),
        (1.220, 2.8791143187894),
    ],
    cat='LIGHTPATH'
)

# Register it globally
opticalglass.register_glass(VIG06)

# Now any ray-optics model using 'VIG06' will find it automatically:
from rayoptics.environment import open_model
open_model('110V-D.zmx')  # this Thorlabs lens uses VIG06
```
This approach is fully backward-compatible (no API changes to `create_glass`, no extra dependencies), and simply intercepts lookups by name/catalog to return user-defined media when present.

### Questions & next steps

Does this idea fit the project’s goals?
Would you prefer a different API shape (e.g. separate module, config file, etc.)?

I’m eager to hear your feedback and happy to refine the implementation/docs to align with the library’s design. Thanks for considering this discussion!