### PR TITLE
Implement save/load_custom_glasses

### DIFF
--- a/docs/OG_Quickstart/OG_Quickstart.rst
+++ b/docs/OG_Quickstart/OG_Quickstart.rst
@@ -22,6 +22,7 @@ Command Line Quick Start
     import opticalglass.glassmap as gm
     from opticalglass.glassfactory import create_glass
 
+
 Creating a Glass Object
 -----------------------
 
@@ -70,6 +71,54 @@ Use the :meth:`~.glass.GlassPandas.rindex` method of the glass object to get the
 .. parsed-literal::
 
     (1.5143223472613747, 1.5168000345005885, 1.5223762897312285)
+
+
+Defining a user-defined Glass object
+------------------------------------
+
+It is also possible to work with a user-defined Glass object. There are several types of Glass objects available. 
+One particularly useful class is :class:`~.opticalmedium.InterpolatedMedium`, which creates a glass object by interpolating between a finite number of (wavelength, refractive index) data points.
+
+For example, 'BD-2' is an infrared glass material whose refractive index is [tabulated](https://refractiveindex.info/download/data/2013/BD-2.pdf) by the manufacturer.
+To create a Glass object,
+
+
+.. code:: ipython3
+
+  from opticalglass import opticalmedium as om
+
+  # A list of ([wavelength in nm], [refractive index]) pairs
+  pairs = [
+    (3000, 2.6266), (4000, 2.6210), (5000, 2.6173), (6000, 2.6142), (7000, 2.6117),
+    (8000, 2.6088), (9000, 2.6055), (10000, 2.6023), (11000, 2.5983), (12000, 2.5942),
+    (13000, 2.5892), (14000, 2.5843)
+  ]
+  # user-defined glass object
+  glass = om.InterpolatedMedium('BD2', pairs=pairs, cat='LIGHTPATH')
+
+  # Then, this can be used as the same way to the predefined glass object
+  glass.rindex(2500)
+
+.. parsed-literal::
+  array(2.6306544)
+
+
+We can also *register* this user-defined glass by :func:`~.glassfactory.register_glass`
+
+.. code:: ipython3
+
+  from opticalglass.glassfactory import register_glass
+  register_glass(glass)
+
+Now, we can access to the glass from the name (`BD2`) and catalog (`LIGHTPATH`)
+
+.. code:: ipython3
+
+  create_glass('BD2', 'LIGHTPATH')
+
+.. parsed-literal::
+
+  InterpolatedMedium('BD2', cat='LIGHTPATH', wvls=[3000, 4000, ..., 14000], rndx=[2.6266, 2.621, ..., 2.5843], kvals_wvls=None, kvals=None)
 
 
 

--- a/src/opticalglass/glassfactory.py
+++ b/src/opticalglass/glassfactory.py
@@ -39,7 +39,28 @@ def register_glass(
     medium: OpticalMedium
 ):
     """
-    Register a custom glass.
+    Registers a custom optical glass medium in the internal registry.
+
+    This function adds a user-defined `OpticalMedium` instance to the custom glass registry,
+    allowing it to be referenced and used elsewhere in the application. The medium is
+    indexed by a tuple of its name and catalog name. If the catalog name is new, it is
+    also added to the list of known catalog names (both in original and uppercase forms).
+
+    Parameters:
+        medium (OpticalMedium): The optical medium instance to register. Must be an instance
+            of the `OpticalMedium` class, and have a valid `name` and `catalog_name`.
+
+    Raises:
+        TypeError: If `medium` is not an instance of `OpticalMedium`.
+
+    Side Effects:
+        - Updates the `_custom_glass_registry` dictionary with the new medium.
+
+    Example:
+        >>> custom_medium = OpticalMedium(name="MyGlass", catalog_name="CustomCat", ...)
+        >>> register_glass(custom_medium)
+        >>> # Now `custom_medium` can be accessed via name and catalog
+        >>> glass = create_glass("MyGlass,CustomCat")
     """
     key = (medium.name(), medium.catalog_name())
     if not isinstance(medium, OpticalMedium):

--- a/src/opticalglass/glassfactory.py
+++ b/src/opticalglass/glassfactory.py
@@ -44,6 +44,21 @@ def register_glass(
     if not isinstance(medium, OpticalMedium):
         raise TypeError('medium must be an instance of OpticalMedium')
     _custom_glass_registry[key] = medium
+    if medium.catalog_name() not in _cat_names:
+        _cat_names.append(medium.catalog_name())
+        _cat_names_uc.append(medium.catalog_name().upper())
+
+
+class CustomGlassCatalog:
+    def __init__(self, cat):
+        self.catalog_name = cat
+        self.glass_list = [
+            # should return (gname_decode, gname, catalog) but gname_decode
+            # may not be defined for custom glasses. 
+            # gname_decode is supposed to be group_num, prefix, suffix. 
+            (('__NA__', '', ''), name, cat) for name, cat in _custom_glass_registry.keys()
+            if cat == cat
+        ]
 
 
 def save_custom_glasses(dirname):
@@ -159,6 +174,8 @@ def get_glass_catalog(cat_name, mod_name=None, cls_name=None):
     """
     if cat_name in _catalog_list:
         return _catalog_list[cat_name]
+    elif cat_name in [cat for _, cat in _custom_glass_registry.keys()]:
+        return CustomGlassCatalog(cat_name)
     else:
         try:
             if "Robb1983" in cat_name:

--- a/src/opticalglass/glassfactory.py
+++ b/src/opticalglass/glassfactory.py
@@ -12,6 +12,8 @@
 """
 import logging
 
+import os
+import json_tricks
 from . import glass as cat_glass
 from . import glasserror as ge
 from . import rindexinfo
@@ -42,6 +44,38 @@ def register_glass(
     if not isinstance(medium, OpticalMedium):
         raise TypeError('medium must be an instance of OpticalMedium')
     _custom_glass_registry[key] = medium
+
+
+def save_custom_glasses(dirname):
+    '''
+    Save the custom glasses to the specified directory.
+    '''
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+    for (name, catalog), medium in _custom_glass_registry.items():
+        catalog_dir = os.path.join(dirname, catalog.lower())
+        if not os.path.exists(catalog_dir):
+            os.makedirs(catalog_dir)
+
+        filename = os.path.join(catalog_dir, f'{name}.json')
+            
+        with open(filename, 'w') as f:
+            json_tricks.dump(medium, f, indent=4)
+
+
+def load_custom_glasses(dirname):
+    '''
+    Load custom glasses from the specified directory.
+    '''
+    if not os.path.exists(dirname):
+        raise FileNotFoundError(f'Directory {dirname} does not exist')
+
+    for root, _, files in os.walk(dirname):
+        for filename in files:
+            if filename.endswith('.json'):
+                with open(os.path.join(root, filename), 'r') as f:
+                    medium = json_tricks.load(f)
+                    register_glass(medium)
 
 
 def create_glass(*name_catalog):

--- a/src/opticalglass/glassfactory.py
+++ b/src/opticalglass/glassfactory.py
@@ -13,6 +13,7 @@
 import logging
 
 import os
+from pathlib import Path
 import json_tricks
 from . import glass as cat_glass
 from . import glasserror as ge
@@ -68,11 +69,7 @@ def save_custom_glasses(dirname):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     for (name, catalog), medium in _custom_glass_registry.items():
-        catalog_dir = os.path.join(dirname, catalog.lower())
-        if not os.path.exists(catalog_dir):
-            os.makedirs(catalog_dir)
-
-        filename = os.path.join(catalog_dir, f'{name}.json')
+        filename = Path(dirname) / f'{catalog}_{name}.json'
             
         with open(filename, 'w') as f:
             json_tricks.dump(medium, f, indent=4)

--- a/src/opticalglass/test/test_create_glass.py
+++ b/src/opticalglass/test/test_create_glass.py
@@ -6,10 +6,10 @@
 """
 
 import unittest
-from opticalglass.glassfactory import create_glass
+from opticalglass.glassfactory import create_glass, register_glass, save_custom_glasses, load_custom_glasses
 from opticalglass import glasserror as ge
 import opticalglass.opticalmedium as om
-
+from opticalglass import modelglass
 
 class CreateGlassTestCase(unittest.TestCase):
 
@@ -74,6 +74,36 @@ class CreateGlassTestCase(unittest.TestCase):
         )
         medium = create_glass('myglass', 'mycatalog')
         self.assertIsInstance(medium, om.OpticalMedium)
+
+    def test_save_load_custom_glass(self):
+        """ test registering a glass """
+        import opticalglass.glassfactory
+
+        # register a glass
+        register_glass(om.InterpolatedMedium(
+            'myglass', [(600, 1.5), (610, 1.6), (620, 1.61), (630, 1.62)], cat='mycatalog')
+        )
+        # test modelglass as well
+        register_glass(modelglass.ModelGlass(
+            nd=1.61, vd=50, mat='anotherglass', cat='mycatalog')
+        )
+        # temporarily save the glass to a file
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as dirname:
+            save_custom_glasses(dirname)
+
+            # check that the glass is saved
+            self.assertTrue(os.path.exists(os.path.join(dirname, 'mycatalog/myglass.json')))
+
+            # Force to forget the registered glass
+            opticalglass.glassfactory._custom_glass_registry = {}
+            load_custom_glasses(dirname)
+            medium = create_glass('myglass', 'mycatalog')
+            self.assertIsInstance(medium, om.OpticalMedium)
+            medium = create_glass('anotherglass', 'mycatalog')
+            self.assertIsInstance(medium, om.OpticalMedium)
 
 
 if __name__ == '__main__':

--- a/src/opticalglass/test/test_create_glass.py
+++ b/src/opticalglass/test/test_create_glass.py
@@ -6,10 +6,15 @@
 """
 
 import unittest
-from opticalglass.glassfactory import create_glass, register_glass, save_custom_glasses, load_custom_glasses
+from opticalglass.glassfactory import (
+    create_glass, register_glass, save_custom_glasses, load_custom_glasses,
+    get_glass_catalog
+)
 from opticalglass import glasserror as ge
 import opticalglass.opticalmedium as om
 from opticalglass import modelglass
+from opticalglass import glass as cat_glass
+
 
 class CreateGlassTestCase(unittest.TestCase):
 
@@ -74,6 +79,20 @@ class CreateGlassTestCase(unittest.TestCase):
         )
         medium = create_glass('myglass', 'mycatalog')
         self.assertIsInstance(medium, om.OpticalMedium)
+
+        # make sure get_glass_catalog returns the catalog
+        cat = get_glass_catalog('mycatalog')
+        found = False
+        for g in cat.glass_list:
+            if g[1] == 'myglass':
+                found = True
+                # mimic zmxread by accessing glass[0][0] and glass[0][1]
+                gn_decode, gn, gc = g
+                # just make sure gn_decode has 3 elements
+                self.assertTrue(len(gn_decode) == 3) 
+                    
+        self.assertTrue(found)
+
 
     def test_save_load_custom_glass(self):
         """ test registering a glass """

--- a/src/opticalglass/test/test_create_glass.py
+++ b/src/opticalglass/test/test_create_glass.py
@@ -93,7 +93,6 @@ class CreateGlassTestCase(unittest.TestCase):
                     
         self.assertTrue(found)
 
-
     def test_save_load_custom_glass(self):
         """ test registering a glass """
         import opticalglass.glassfactory
@@ -114,7 +113,7 @@ class CreateGlassTestCase(unittest.TestCase):
             save_custom_glasses(dirname)
 
             # check that the glass is saved
-            self.assertTrue(os.path.exists(os.path.join(dirname, 'mycatalog/myglass.json')))
+            self.assertTrue(os.path.exists(os.path.join(dirname, 'mycatalog_myglass.json')))
 
             # Force to forget the registered glass
             opticalglass.glassfactory._custom_glass_registry = {}


### PR DESCRIPTION
Closes #13 

As discussed in #12 and #13, I implemented `save_custom_glasses`, `load_custom_glasses`.

### Some design considerations
#### File structure
Currently, the filename is '{catalog}/{name}.json'. Maybe flattening all the files, '{catalog}_{name}.json', would be equally OK.

#### Filename
Currently, filenames are arbitrary and will be ignored. The glass name and catalog is taken from the `.name` attribute.
This might be confusing if there is more than one files having the same name/catalog entry. We can add some sanity checks.

#### Documentations
Where is a good place to write about this and `register_glass`? 