### PR TITLE
instance interp after loading custom glass

### DIFF
--- a/src/opticalglass/opticalmedium.py
+++ b/src/opticalglass/opticalmedium.py
@@ -185,6 +185,13 @@ class InterpolatedMedium(OpticalMedium):
             del attrs['yaml_data']
         return attrs
 
+    def __json_decode__(self, **attrs) -> None:
+        """ Rebuild the interpolating functions from the stored data """
+        for key, value in attrs.items():
+            setattr(self, key, value) 
+        # create the interpolation instances, which is not saved in json file
+        self.update()
+
     def sync_to_restore(self) -> None:
         """ rebuild interpolating function """
         self.update()

--- a/src/opticalglass/test/test_create_glass.py
+++ b/src/opticalglass/test/test_create_glass.py
@@ -118,11 +118,12 @@ class CreateGlassTestCase(unittest.TestCase):
             # Force to forget the registered glass
             opticalglass.glassfactory._custom_glass_registry = {}
             load_custom_glasses(dirname)
-            medium = create_glass('myglass', 'mycatalog')
-            self.assertIsInstance(medium, om.OpticalMedium)
             medium = create_glass('anotherglass', 'mycatalog')
             self.assertIsInstance(medium, om.OpticalMedium)
-
+            medium = create_glass('myglass', 'mycatalog')
+            self.assertIsInstance(medium, om.OpticalMedium)
+            # make sure medium can give refractive index
+            self.assertAlmostEqual(medium.rindex(610), 1.6, places=2)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Sorry, #14 was not working; after loading `InterpolatedMedium` from a json, we needed to prepare for the interpolation.
Otherwise, this gives
```python
AttributeError: 'InterpolatedMedium' object has no attribute 'rindex_interp'
```

This PR solves this problem.